### PR TITLE
(General) Banner - fix header and banner not appearing

### DIFF
--- a/frontend/src/components/ui/BannerHeader/BannerHeader.module.css
+++ b/frontend/src/components/ui/BannerHeader/BannerHeader.module.css
@@ -17,18 +17,20 @@
     background-repeat: no-repeat;
     filter: blur(2px);
     clip-path: polygon(0 0, 100% 0, 100% 100%, 0 calc(100% - min(11vw, 175px)));
-    z-index: -1;
+    z-index: 0;
   }
 
   h1 {
     margin-bottom: 30px;
     font-size: 64px;
     font-weight: bold;
+    z-index: 1;
   }
 
   h2 {
     margin-bottom: 30px;
     font-size: 40px;
     font-weight: normal;
+    z-index: 1;
   }
 }


### PR DESCRIPTION
Fixes #40 

Issue was caused by the banner background being hidden behind page, and since the header text colour is white, it would blend into the background. Resolved by adjusting the z-index of the respective elements.